### PR TITLE
Fix bug relating to clicking the buttons

### DIFF
--- a/src/comp/Editor.js
+++ b/src/comp/Editor.js
@@ -16,7 +16,7 @@ export class Editor extends React.Component {
     }
 
     updateButtons(e) {
-        var name = e.target.name,
+        var name = e.target.name || e.target.parentNode.name,
             val = this.props.data[name];
 
         console.log(val);
@@ -32,7 +32,7 @@ export class Editor extends React.Component {
             window.alert("aaaaaaaaaaaaaa");
         }
 
-        this.props.update(e.target.name, val);
+        this.props.update(name, val);
     }
 
     changeType(e) {


### PR DESCRIPTION
**Bug:**

When clicking the text format buttons, the related text effect is not always activated (Also mentioned inside todo.txt)

**Reproduction:**

1. Click the button (B, I, U, S)

**Expected:**

Clicking the button should always trigger the texts status effect

**Actual:**

Clicking the text doesn't trigger the effect, but the area outside does trigger the effect

**Description:**

Inside the handler for the button, it checks for the name of the clicked node. This fails when clicking the text, as the text is nested inside an text element without a name

**Fix:**

This PR fixes this bug by checking the parent node if the current node doesn't have a name, this works for all the buttons inside the dialog